### PR TITLE
ci: remove `no-commit-to-branch` pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,6 @@ repos:
       - id: forbid-new-submodules
       - id: forbid-submodules
       - id: mixed-line-ending
-      - id: no-commit-to-branch
       - id: trailing-whitespace
 
   - repo: https://github.com/psf/black


### PR DESCRIPTION
allow squash and rebase commit to `main` branch

protect normal commit to `main` branch via GitHub branch protection rule