### PR TITLE
ci: re-enable `no-commit-to-branch` pre-commit hook

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+    env:
+      SKIP: no-commit-to-branch
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ repos:
       - id: forbid-new-submodules
       - id: forbid-submodules
       - id: mixed-line-ending
+      - id: no-commit-to-branch
       - id: trailing-whitespace
 
   - repo: https://github.com/psf/black


### PR DESCRIPTION
- Enable locally

- Disable `no-commit-to-branch` on CI via [`SKIP`](https://github.com/pre-commit/pre-commit-hooks/issues/265#issuecomment-792805360)

- Revert https://github.com/ge69tez/mcr-analyzer/pull/4