### PR TITLE
fix: remove unnecessary license headers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,19 @@
 Copyright (c) 2021 Martin Knopp, Technical University of Munich
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/analyzer.py
+++ b/analyzer.py
@@ -1,11 +1,3 @@
-#
-# MCR-Analyzer
-#
-# Copyright (C) 2021 Martin Knopp, Technical University of Munich
-#
-# This program is free software, see the LICENSE file in the root of this
-# repository for details
-
 from mcr_analyzer.analyzer import main
 
 main()

--- a/mcr_analyzer/analyzer.py
+++ b/mcr_analyzer/analyzer.py
@@ -1,11 +1,3 @@
-#
-# MCR-Analyzer
-#
-# Copyright (C) 2021 Martin Knopp, Technical University of Munich
-#
-# This program is free software, see the LICENSE file in the root of this
-# repository for details
-
 import sys
 
 from qtpy import QtWidgets

--- a/mcr_analyzer/database/database.py
+++ b/mcr_analyzer/database/database.py
@@ -1,11 +1,3 @@
-#
-# MCR-Analyzer
-#
-# Copyright (C) 2021 Martin Knopp, Technical University of Munich
-#
-# This program is free software, see the LICENSE file in the root of this
-# repository for details
-
 """Database routines for setup and usage."""
 
 

--- a/mcr_analyzer/database/models.py
+++ b/mcr_analyzer/database/models.py
@@ -1,11 +1,3 @@
-#
-# MCR-Analyzer
-#
-# Copyright (C) 2021 Martin Knopp, Technical University of Munich
-#
-# This program is free software, see the LICENSE file in the root of this
-# repository for details
-
 """Object Relational Models defining the database."""
 
 import datetime

--- a/mcr_analyzer/io/image.py
+++ b/mcr_analyzer/io/image.py
@@ -1,11 +1,3 @@
-#
-# MCR-Analyzer
-#
-# Copyright (C) 2021 Martin Knopp, Technical University of Munich
-#
-# This program is free software, see the LICENSE file in the root of this
-# repository for details
-
 """Image functions related to MCR measurements"""
 
 import re

--- a/mcr_analyzer/io/importer.py
+++ b/mcr_analyzer/io/importer.py
@@ -1,11 +1,3 @@
-#
-# MCR-Analyzer
-#
-# Copyright (C) 2021 Martin Knopp, Technical University of Munich
-#
-# This program is free software, see the LICENSE file in the root of this
-# repository for details
-
 """Import functions related to MCR measurements."""
 
 import copy

--- a/mcr_analyzer/processing/measurement.py
+++ b/mcr_analyzer/processing/measurement.py
@@ -1,11 +1,3 @@
-#
-# MCR-Analyzer
-#
-# Copyright (C) 2021 Martin Knopp, Technical University of Munich
-#
-# This program is free software, see the LICENSE file in the root of this
-# repository for details
-
 import numpy as np
 
 from mcr_analyzer.database.database import Database

--- a/mcr_analyzer/processing/spot.py
+++ b/mcr_analyzer/processing/spot.py
@@ -1,11 +1,3 @@
-#
-# MCR-Analyzer
-#
-# Copyright (C) 2021 Martin Knopp, Technical University of Munich
-#
-# This program is free software, see the LICENSE file in the root of this
-# repository for details
-
 """Interface and classes for spot analysis."""
 
 from abc import ABCMeta, abstractmethod

--- a/mcr_analyzer/processing/validator.py
+++ b/mcr_analyzer/processing/validator.py
@@ -1,11 +1,3 @@
-#
-# MCR-Analyzer
-#
-# Copyright (C) 2021 Martin Knopp, Technical University of Munich
-#
-# This program is free software, see the LICENSE file in the root of this
-# repository for details
-
 """Validation functions for replicates."""
 
 from abc import ABCMeta, abstractmethod

--- a/mcr_analyzer/ui/exporter.py
+++ b/mcr_analyzer/ui/exporter.py
@@ -1,11 +1,3 @@
-#
-# MCR-Analyzer
-#
-# Copyright (C) 2021 Martin Knopp, Technical University of Munich
-#
-# This program is free software, see the LICENSE file in the root of this
-# repository for details
-
 import datetime
 import numbers
 import operator

--- a/mcr_analyzer/ui/graphics_scene.py
+++ b/mcr_analyzer/ui/graphics_scene.py
@@ -1,11 +1,3 @@
-#
-# MCR-Analyzer
-#
-# Copyright (C) 2021 Martin Knopp, Technical University of Munich
-#
-# This program is free software, see the LICENSE file in the root of this
-# repository for details
-
 import string
 
 from qtpy import QtCore, QtGui, QtWidgets

--- a/mcr_analyzer/ui/importer.py
+++ b/mcr_analyzer/ui/importer.py
@@ -1,11 +1,3 @@
-#
-# MCR-Analyzer
-#
-# Copyright (C) 2021 Martin Knopp, Technical University of Munich
-#
-# This program is free software, see the LICENSE file in the root of this
-# repository for details
-
 import hashlib
 
 import numpy as np

--- a/mcr_analyzer/ui/main_window.py
+++ b/mcr_analyzer/ui/main_window.py
@@ -1,11 +1,3 @@
-#
-# MCR-Analyzer
-#
-# Copyright (C) 2021 Martin Knopp, Technical University of Munich
-#
-# This program is free software, see the LICENSE file in the root of this
-# repository for details
-
 import contextlib
 from pathlib import Path
 

--- a/mcr_analyzer/ui/measurement.py
+++ b/mcr_analyzer/ui/measurement.py
@@ -1,11 +1,3 @@
-#
-# MCR-Analyzer
-#
-# Copyright (C) 2021 Martin Knopp, Technical University of Munich
-#
-# This program is free software, see the LICENSE file in the root of this
-# repository for details
-
 import numpy as np
 from qtpy import QtCore, QtGui, QtWidgets
 

--- a/mcr_analyzer/ui/models.py
+++ b/mcr_analyzer/ui/models.py
@@ -1,11 +1,3 @@
-#
-# MCR-Analyzer
-#
-# Copyright (C) 2021 Martin Knopp, Technical University of Munich
-#
-# This program is free software, see the LICENSE file in the root of this
-# repository for details
-
 import datetime
 import string
 import time

--- a/mcr_analyzer/ui/welcome.py
+++ b/mcr_analyzer/ui/welcome.py
@@ -1,11 +1,3 @@
-#
-# MCR-Analyzer
-#
-# Copyright (C) 2021 Martin Knopp, Technical University of Munich
-#
-# This program is free software, see the LICENSE file in the root of this
-# repository for details
-
 from pathlib import Path
 
 from qtpy import QtCore, QtWidgets

--- a/mcr_analyzer/utils/__init__.py
+++ b/mcr_analyzer/utils/__init__.py
@@ -1,12 +1,3 @@
-#
-# MCR-Analyzer
-#
-# Copyright (C) 2021 Martin Knopp, Technical University of Munich
-#
-# This program is free software, see the LICENSE file in the root of this
-# repository for details
-
-
 def ensure_list(var):
     """Ensure var is list or tuple.
 

--- a/tests/io/image_test.py
+++ b/tests/io/image_test.py
@@ -1,11 +1,3 @@
-#
-# MCR-Analyzer
-#
-# Copyright (C) 2021 Martin Knopp, Technical University of Munich
-#
-# This program is free software, see the LICENSE file in the root of this
-# repository for details
-
 """Test module for io.images """
 
 from pathlib import Path

--- a/tests/utils/utils_test.py
+++ b/tests/utils/utils_test.py
@@ -1,11 +1,3 @@
-#
-# MCR-Analyzer
-#
-# Copyright (C) 2021 Martin Knopp, Technical University of Munich
-#
-# This program is free software, see the LICENSE file in the root of this
-# repository for details
-
 """Test module for utils"""
 
 from mcr_analyzer import utils


### PR DESCRIPTION
License MIT doesn't have a header.
https://opensource.org/license/mit/