### PR TITLE
style: change `line-length` back to `120`

### DIFF
--- a/.github/disabled-workflows/run-tests.yml
+++ b/.github/disabled-workflows/run-tests.yml
@@ -19,16 +19,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install .[tests]
-      - name: Check coding style (flake8)
-        run: |
-          flake8 \
-            --count \
-            --show-source \
-            --statistics \
-            --max-line-length=120 \
-            --builtins=_ \
-            --ignore=E121,E123,E126,E203,E226,E24,E704,W503,W504 \
-            mcr_analyzer
       - name: Check coding errors (pylint)
         run: |
           pylint \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,11 +52,11 @@ mcr_analyzer = "python -m mcr_analyzer"
 
 [tool.black]
 target-version = ["py311"]
-line-length = 100
+line-length = 120
 
 [tool.ruff]
 target-version = "py311"
-line-length = 100
+line-length = 120
 src = ["src"]
 namespace-packages = ["docs"]
 show-fixes = true

--- a/src/mcr_analyzer/database/database.py
+++ b/src/mcr_analyzer/database/database.py
@@ -2,10 +2,7 @@
 
 
 from sqlalchemy import URL, create_engine
-from sqlalchemy.orm import (
-    Session,
-    sessionmaker,  # cSpell:ignore sessionmaker
-)
+from sqlalchemy.orm import Session, sessionmaker  # cSpell:ignore sessionmaker
 
 from mcr_analyzer.database.models import Base
 
@@ -26,10 +23,7 @@ class _DatabaseSingleton:
             return session.get_bind()
 
     def configure(self, engine_url: URL):
-        engine = create_engine(
-            url=engine_url,
-            connect_args={"timeout": 30},
-        )
+        engine = create_engine(url=engine_url, connect_args={"timeout": 30})
 
         self.Session.configure(bind=engine)
 

--- a/src/mcr_analyzer/database/models.py
+++ b/src/mcr_analyzer/database/models.py
@@ -2,11 +2,7 @@
 
 import datetime
 
-from sqlalchemy import (
-    BINARY,
-    ForeignKey,
-    Text,
-)
+from sqlalchemy import BINARY, ForeignKey, Text
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
 
@@ -24,8 +20,7 @@ class Chip(Base):
     """Chip ID assigned by user during measurement."""
 
     rowCount: Mapped[int]  # noqa: N815
-    """Number of rows, typically five. Used for redundancy and error
-    reduction."""
+    """Number of rows, typically five. Used for redundancy and error reduction."""
 
     columnCount: Mapped[int]  # noqa: N815
     """Number of columns. Different anti-bodies or anti-gens."""
@@ -40,16 +35,12 @@ class Chip(Base):
     """Size (in pixels) of a single spot. Side length of the square used for processing."""
 
     spotMarginHorizontal: Mapped[int]  # noqa: N815
-    """Horizontal margin between two adjacent spots: skip N pixels before processing the next
-    spot."""
+    """Horizontal margin between two adjacent spots: skip N pixels before processing the next spot."""
 
     spotMarginVertical: Mapped[int]  # noqa: N815
     """Vertical margin between two adjacent spots: skip N pixels before processing the next spot."""
 
-    measurements: Mapped[list["Measurement"]] = relationship(
-        back_populates="chip",
-        order_by="Measurement.timestamp",
-    )
+    measurements: Mapped[list["Measurement"]] = relationship(back_populates="chip", order_by="Measurement.timestamp")
     """Many-to-One relationship referencing all measurements the chip was used for."""
 
 
@@ -64,10 +55,7 @@ class Device(Base):
     serial: Mapped[str]
     """Serial number of the device."""
 
-    measurements: Mapped[list["Measurement"]] = relationship(
-        back_populates="device",
-        order_by="Measurement.timestamp",
-    )
+    measurements: Mapped[list["Measurement"]] = relationship(back_populates="device", order_by="Measurement.timestamp")
     """Many-to-One relationship referencing all measurements done with this device."""
 
 
@@ -119,19 +107,15 @@ class Measurement(Base):
     notes: Mapped[str | None] = mapped_column(Text)
     """Additional notes."""
 
-    results: Mapped[list["Result"]] = relationship(
-        back_populates="measurement",
-        order_by="Result.id",
-    )
+    results: Mapped[list["Result"]] = relationship(back_populates="measurement", order_by="Result.id")
     """Many-to-One relationship referencing all results of this measurement."""
 
 
 class Reagent(Base):
     """Substance used on a chip.
 
-    This class handles column specific information (for end-users), so depending on what information
-    is more useful, this is about the reagent which should be detected or the reagent which is
-    initially put on the chip.
+    This class handles column specific information (for end-users), so depending on what information is more useful,
+    this is about the reagent which should be detected or the reagent which is initially put on the chip.
     """
 
     __tablename__ = "reagent"
@@ -154,10 +138,7 @@ class Result(Base):
     id: Mapped[int] = mapped_column(primary_key=True)
     """Internal ID, used for cross-references."""
 
-    measurementID: Mapped[int] = mapped_column(  # noqa: N815
-        ForeignKey("measurement.id"),
-        index=True,
-    )
+    measurementID: Mapped[int] = mapped_column(ForeignKey("measurement.id"), index=True)  # noqa: N815
     """Reference to the :class:`Measurement` to which the result belongs."""
 
     measurement: Mapped["Measurement"] = relationship(back_populates="results")
@@ -172,10 +153,7 @@ class Result(Base):
     value: Mapped[float | None]
     """Calculated brightness of the spot."""
 
-    reagentID: Mapped[int | None] = mapped_column(  # noqa: N815
-        ForeignKey("reagent.id"),
-        index=True,
-    )
+    reagentID: Mapped[int | None] = mapped_column(ForeignKey("reagent.id"), index=True)  # noqa: N815
     """Reference to :class:`Reagent`."""
 
     reagent: Mapped["Reagent"] = relationship(back_populates="results")
@@ -185,9 +163,8 @@ class Result(Base):
     """Additional concentration information to specify the :attr:`reagent` more precisely."""
 
     valid: Mapped[bool | None]
-    """Is this a valid result which can be used in calculations? Invalid results can be caused by
-    the process (bleeding of nearby results, air bubbles, or dirt) or determination as an outlier
-    (mathematical postprocessing)."""
+    """Is this a valid result which can be used in calculations? Invalid results can be caused by the process (bleeding
+    of nearby results, air bubbles, or dirt) or determination as an outlier (mathematical postprocessing)."""
 
 
 class Sample(Base):
@@ -202,13 +179,9 @@ class Sample(Base):
     """Short description of the sample, entered as Probe ID during measurement."""
 
     knownPositive: Mapped[bool | None]  # noqa: N815
-    """Is this a know positive sample? Makes use of the tri-state SQL bool `None`, `True`, or
-    `False`."""
+    """Is this a know positive sample? Makes use of the tri-state SQL bool `None`, `True`, or `False`."""
 
-    typeID: Mapped[int | None] = mapped_column(  # noqa: N815
-        ForeignKey("sampleType.id"),
-        index=True,
-    )
+    typeID: Mapped[int | None] = mapped_column(ForeignKey("sampleType.id"), index=True)  # noqa: N815
     """Refers to :class:`SampleType`."""
 
     type: Mapped["SampleType"] = relationship(back_populates="samples")
@@ -223,10 +196,7 @@ class Sample(Base):
     timestamp: Mapped[datetime.datetime | None]
     """Date and time of the sample taking."""
 
-    measurements: Mapped[list["Measurement"]] = relationship(
-        back_populates="sample",
-        order_by="Measurement.timestamp",
-    )
+    measurements: Mapped[list["Measurement"]] = relationship(back_populates="sample", order_by="Measurement.timestamp")
     """Many-to-One relationship referencing the measurements done with this sample."""
 
 
@@ -262,8 +232,5 @@ class User(Base):
     samples: Mapped[list["Sample"]] = relationship(back_populates="takenBy", order_by="Sample.id")
     """Many-to-One relationship referencing all samples taken by a user."""
 
-    measurements: Mapped[list["Measurement"]] = relationship(
-        back_populates="user",
-        order_by="Measurement.timestamp",
-    )
+    measurements: Mapped[list["Measurement"]] = relationship(back_populates="user", order_by="Measurement.timestamp")
     """Many-to-One relationship referencing all measurements done by a user."""

--- a/src/mcr_analyzer/io/importer.py
+++ b/src/mcr_analyzer/io/importer.py
@@ -39,9 +39,7 @@ class FileImporter:
                 for i, name in enumerate(sorted(rslt.dir.glob(f"{base}-*.pgm"))):
                     temp_result = copy.deepcopy(rslt)
                     temp_result.meta["Result image PGM"] = name.name
-                    temp_result.meta["Date/time"] = rslt.meta["Date/time"] + datetime.timedelta(
-                        seconds=i,
-                    )
+                    temp_result.meta["Date/time"] = rslt.meta["Date/time"] + datetime.timedelta(seconds=i)
                     measurements.append(temp_result)
         return measurements, failed
 
@@ -114,15 +112,11 @@ class RsltParser:
                     self._meta[match.group(1)] = match.group(2)
 
             # Post-process results (map to corresponding types)
-            self._meta["Date/time"] = datetime.datetime.strptime(
-                self._meta["Date/time"],
-                "%Y-%m-%d %H:%M",
-            ).replace(tzinfo=TZ_INFO)
+            self._meta["Date/time"] = datetime.datetime.strptime(self._meta["Date/time"], "%Y-%m-%d %H:%M").replace(
+                tzinfo=TZ_INFO,
+            )
 
-            if (
-                self._meta["Dark frame image PGM"]
-                == "Do not store PGM file for dark frame any more"
-            ):
+            if self._meta["Dark frame image PGM"] == "Do not store PGM file for dark frame any more":
                 self._meta["Dark frame image PGM"] = None
 
             self._meta["Temperature ok"] = self._meta["Temperature ok"] == "yes"
@@ -156,20 +150,14 @@ class RsltParser:
             # Store as (x,y) tuple in a table like results
             coordinates_data_type = np.dtype([("x", np.int64), ("y", np.int64)])
             # cSpell:ignore dtype
-            spots = np.fromiter(
-                [self._parse_spot_coordinates(x) for x in results.flat],
-                coordinates_data_type,
-            )
+            spots = np.fromiter([self._parse_spot_coordinates(x) for x in results.flat], coordinates_data_type)
             # cSpell:ignore fromiter
             self._spots = spots.reshape(self.results.shape)
 
             # Compute grid settings from spots
             self._meta["Margin left"] = int(self._spots[0, 0][0])
             self._meta["Margin top"] = int(self._spots[0, 0][1])
-            spot_margin = (
-                np.subtract(tuple(self._spots[1, 1]), tuple(self._spots[0, 0]))
-                - self._meta["Spot size"]
-            )
+            spot_margin = np.subtract(tuple(self._spots[1, 1]), tuple(self._spots[0, 0])) - self._meta["Spot size"]
             self._meta["Spot margin horizontal"] = int(spot_margin[0])
             self._meta["Spot margin vertical"] = int(spot_margin[1])
 

--- a/src/mcr_analyzer/processing/measurement.py
+++ b/src/mcr_analyzer/processing/measurement.py
@@ -13,11 +13,7 @@ class Measurement:
 
     def update_results(self, measurement_id: int):
         with self.db.Session() as session:
-            measurement = (
-                session.query(MeasurementModel)
-                .filter(MeasurementModel.id == measurement_id)
-                .one_or_none()
-            )
+            measurement = session.query(MeasurementModel).filter(MeasurementModel.id == measurement_id).one_or_none()
 
             for col in range(measurement.chip.columnCount):
                 col_results = []
@@ -35,13 +31,7 @@ class Measurement:
                         ],
                         # cSpell:ignore frombuffer dtype
                     )
-                    result = self.db.get_or_create(
-                        session,
-                        Result,
-                        measurement=measurement,
-                        row=row,
-                        column=col,
-                    )
+                    result = self.db.get_or_create(session, Result, measurement=measurement, row=row, column=col)
                     result.value = spot.value()
                     session.add(result)
                     col_results.append(result.value)
@@ -49,13 +39,7 @@ class Measurement:
                 validation = validator.validate()
 
                 for row in range(measurement.chip.rowCount):
-                    result = self.db.get_or_create(
-                        session,
-                        Result,
-                        measurement=measurement,
-                        row=row,
-                        column=col,
-                    )
+                    result = self.db.get_or_create(session, Result, measurement=measurement, row=row, column=col)
                     result.valid = validation[row]
                     session.add(result)
             session.commit()

--- a/src/mcr_analyzer/processing/validator.py
+++ b/src/mcr_analyzer/processing/validator.py
@@ -26,8 +26,7 @@ class Validator(metaclass=ABCMeta):
 class SpotReaderValidator(Validator):
     r"""Validator based on the Java Spot Reader.
 
-    It finds the three closest spots (value wise), calculates their mean and
-    checks whether the individual values satisfy
+    It find the three closest spots (value wise), calculate their mean and check whether the individual values satisfy
 
     .. math::
 

--- a/src/mcr_analyzer/ui/exporter.py
+++ b/src/mcr_analyzer/ui/exporter.py
@@ -38,9 +38,7 @@ class ExportWidget(QtWidgets.QWidget):
 
         template_group = QtWidgets.QGroupBox("Output template")
         template_layout = QtWidgets.QHBoxLayout()
-        self.template_edit = QtWidgets.QLineEdit(
-            "{timestamp}\t{chip.name}\t{sample.name}\t{sample.note}\t{results}",
-        )
+        self.template_edit = QtWidgets.QLineEdit("{timestamp}\t{chip.name}\t{sample.name}\t{sample.note}\t{results}")
         self.template_edit.setDisabled(True)
         template_layout.addWidget(self.template_edit)
         template_group.setLayout(template_layout)
@@ -55,9 +53,7 @@ class ExportWidget(QtWidgets.QWidget):
         layout.addWidget(preview_group, 1)
 
         self.export_button = QtWidgets.QPushButton(
-            self.style().standardIcon(
-                QtWidgets.QStyle.StandardPixmap.SP_DialogSaveButton,  # cSpell:ignore Pixmap
-            ),
+            self.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_DialogSaveButton),  # cSpell:ignore Pixmap
             "Export as...",
         )
         self.export_button.clicked.connect(self.clicked_export_button)
@@ -139,18 +135,11 @@ class ExportWidget(QtWidgets.QWidget):
                 measurement_line += f"{escape_csv(measurement.chip.name)}\t"
                 measurement_line += f"{escape_csv(measurement.sample.name)}\t"
 
-                measurement_line += (
-                    '""' if measurement.notes is None else f"{escape_csv(measurement.notes)}"
-                )
+                measurement_line += '""' if measurement.notes is None else f"{escape_csv(measurement.notes)}"
 
                 valid_data = False
                 for col in range(measurement.chip.columnCount):
-                    if (
-                        session.query(Result)
-                        .filter_by(measurement=measurement, column=col, valid=True)
-                        .count()
-                        > 0
-                    ):
+                    if session.query(Result).filter_by(measurement=measurement, column=col, valid=True).count() > 0:
                         valid_data = True
                         values = list(
                             session.query(Result)

--- a/src/mcr_analyzer/ui/graphics_scene.py
+++ b/src/mcr_analyzer/ui/graphics_scene.py
@@ -17,15 +17,7 @@ class GraphicsMeasurementScene(QtWidgets.QGraphicsScene):
 class GraphicsRectTextItem(QtWidgets.QGraphicsRectItem):
     """Draws text on a rectangular background."""
 
-    def __init__(  # noqa: PLR0913
-        self,
-        x: float,
-        y: float,
-        w: float,
-        h: float,
-        t: str,
-        parent,
-    ) -> None:
+    def __init__(self, x: float, y: float, w: float, h: float, t: str, parent) -> None:  # noqa: PLR0913
         super().__init__(x, y, w, h, parent)
         self.text = t
         self.setPen(QtGui.QPen(QtCore.Qt.GlobalColor.white))
@@ -83,18 +75,12 @@ class GraphicsSpotItem(QtWidgets.QGraphicsRectItem):
 class GridItem(QtWidgets.QGraphicsItem):
     """Container class for drawing the measurement grid."""
 
-    def __init__(
-        self,
-        meas_id: int,
-        parent=None,
-    ):
+    def __init__(self, meas_id: int, parent=None):
         super().__init__(parent)
         self.meas_id = meas_id
         db = database
         self.session = db.Session()
-        self.measurement = (
-            self.session.query(Measurement).filter(Measurement.id == self.meas_id).one_or_none()
-        )
+        self.measurement = self.session.query(Measurement).filter(Measurement.id == self.meas_id).one_or_none()
         self.cols = self.measurement.chip.columnCount
         self.rows = self.measurement.chip.rowCount
         self.horizontal_space = self.measurement.chip.spotMarginHorizontal
@@ -114,16 +100,9 @@ class GridItem(QtWidgets.QGraphicsItem):
 
     def boundingRect(self):  # noqa: N802
         width = self.cols * self.size + (self.cols - 1) * self.vertical_space + self.pen_width / 2
-        height = (
-            self.rows * self.size + (self.rows - 1) * self.horizontal_space + self.pen_width / 2
-        )
+        height = self.rows * self.size + (self.rows - 1) * self.horizontal_space + self.pen_width / 2
         # Labels are drawn on the "negative" side of the origin
-        return QtCore.QRectF(
-            -self.pen_width / 2 - 15,
-            -self.pen_width / 2 - 15,
-            width + 15,
-            height + 15,
-        )
+        return QtCore.QRectF(-self.pen_width / 2 - 15, -self.pen_width / 2 - 15, width + 15, height + 15)
 
     def itemChange(self, change, value):  # noqa: N802
         if change == QtWidgets.QGraphicsItem.GraphicsItemChange.ItemPositionChange and self.scene():
@@ -206,9 +185,7 @@ class GridItem(QtWidgets.QGraphicsItem):
 
         # Ensure latest database information
         self.session.commit()
-        self.measurement = (
-            self.session.query(Measurement).filter(Measurement.id == self.meas_id).one_or_none()
-        )
+        self.measurement = self.session.query(Measurement).filter(Measurement.id == self.meas_id).one_or_none()
         self.cols = self.measurement.chip.columnCount
         self.rows = self.measurement.chip.rowCount
         self.horizontal_space = self.measurement.chip.spotMarginHorizontal

--- a/src/mcr_analyzer/ui/importer.py
+++ b/src/mcr_analyzer/ui/importer.py
@@ -36,17 +36,12 @@ class ImportWidget(QtWidgets.QWidget):
         self.setLayout(layout)
 
         self.path_button = QtWidgets.QPushButton(
-            self.style().standardIcon(
-                QtWidgets.QStyle.StandardPixmap.SP_DirOpenIcon,  # cSpell:ignore Pixmap
-            ),
+            self.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_DirOpenIcon),  # cSpell:ignore Pixmap
             "Select Folder...",
         )
         self.path_button.setIconSize(QtCore.QSize(48, 48))
         self.path_button.clicked.connect(self.path_dialog)
-        self.path_button.setSizePolicy(
-            QtWidgets.QSizePolicy.Policy.Preferred,
-            QtWidgets.QSizePolicy.Policy.Preferred,
-        )
+        self.path_button.setSizePolicy(QtWidgets.QSizePolicy.Policy.Preferred, QtWidgets.QSizePolicy.Policy.Preferred)
         layout.addWidget(self.path_button)
 
         self.import_button = QtWidgets.QPushButton(
@@ -122,13 +117,9 @@ class ImportWidget(QtWidgets.QWidget):
             self.results, self.failed = imp.gather_measurements(path)
 
             for res in self.failed:
-                error_item = QtGui.QStandardItem(
-                    f"Failed to load '{res}', might be a corrupted file.",
-                )
+                error_item = QtGui.QStandardItem(f"Failed to load '{res}', might be a corrupted file.")
 
-                error_item.setIcon(
-                    self.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_DialogNoButton),
-                )
+                error_item.setIcon(self.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_DialogNoButton))
 
                 measurement = [
                     QtGui.QStandardItem("n. a."),
@@ -165,9 +156,7 @@ class ImportWidget(QtWidgets.QWidget):
         with db.Session() as session:
             try:
                 session.query(Measurement).filter_by(checksum=checksum).one()
-                self.file_model.item(step + len(self.failed), 4).setText(
-                    "Imported previously",
-                )
+                self.file_model.item(step + len(self.failed), 4).setText("Imported previously")
                 self.file_model.item(step + len(self.failed), 4).setIcon(
                     self.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_DialogNoButton),
                 )
@@ -189,11 +178,7 @@ class ImportWidget(QtWidgets.QWidget):
                     spotMarginVertical=rslt.meta["Spot margin vertical"],
                 )
 
-                dev = db.get_or_create(
-                    session,
-                    Device,
-                    serial=rslt.meta["Device ID"],
-                )
+                dev = db.get_or_create(session, Device, serial=rslt.meta["Device ID"])
 
                 sample = db.get_or_create(session, Sample, name=rslt.meta["Probe ID"])
 

--- a/src/mcr_analyzer/ui/main_window.py
+++ b/src/mcr_analyzer/ui/main_window.py
@@ -130,9 +130,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
             settings.setValue(
                 "Session/Files",
-                util.simplify_list(
-                    recent_files[0 : settings.value("Preferences/MaxRecentFiles", 5)],
-                ),
+                util.simplify_list(recent_files[0 : settings.value("Preferences/MaxRecentFiles", 5)]),
             )
             self.measurement_widget.switch_database()
             self.switch_to_measurement()
@@ -171,30 +169,22 @@ class MainWindow(QtWidgets.QMainWindow):
             """
                 <h1>MCR-Analyzer</h1>
 
-                <p>Copyright &copy; 2021 Martin Knopp,
-                Technical University of Munich</p>
+                <p>Copyright &copy; 2021 Martin Knopp, Technical University of Munich</p>
 
-                <p>Permission is hereby granted, free of charge, to any person
-                obtaining a copy of this software and associated documentation
-                files (the "Software"), to deal in the Software without
-                restriction, including without limitation the rights to use,
-                copy, modify, merge, publish, distribute, sublicense, and/or
-                sell copies of the Software, and to permit persons to whom the
-                Software is furnished to do so, subject to the following
-                conditions:</p>
+                <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+                associated documentation files (the "Software"), to deal in the Software without restriction, including
+                without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the
+                following conditions:</p>
 
-                <p>The above copyright notice and this permission notice shall
-                be included in all copies or substantial portions of the
-                Software.</p>
+                <p>The above copyright notice and this permission notice shall be included in all copies or substantial
+                portions of the Software.</p>
 
-                <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
-                KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
-                WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE
-                AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-                HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-                WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-                FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-                OTHER DEALINGS IN THE SOFTWARE.</p>
+                <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+                LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+                NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+                WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+                SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</p>
             """,
         )
 

--- a/src/mcr_analyzer/ui/measurement.py
+++ b/src/mcr_analyzer/ui/measurement.py
@@ -50,15 +50,10 @@ class MeasurementWidget(QtWidgets.QWidget):
         self.spot_size = QtWidgets.QSpinBox()
         form_layout.addRow("Spot size:", self.spot_size)
         self.spot_margin_horizontal = QtWidgets.QSpinBox()
-        form_layout.addRow(
-            "Horizontal Spot Distance:",
-            self.spot_margin_horizontal,
-        )
+        form_layout.addRow("Horizontal Spot Distance:", self.spot_margin_horizontal)
         self.spot_margin_vertical = QtWidgets.QSpinBox()
         form_layout.addRow("Vert. Spot Distance:", self.spot_margin_vertical)
-        self.saveGridButton = QtWidgets.QPushButton(
-            "Save grid and calculate results",
-        )
+        self.saveGridButton = QtWidgets.QPushButton("Save grid and calculate results")
         self.saveGridButton.setDisabled(True)
         self.saveGridButton.clicked.connect(self.save_grid)
         form_layout.addRow(self.saveGridButton)
@@ -116,9 +111,7 @@ class MeasurementWidget(QtWidgets.QWidget):
         db = database
         session = db.Session()
 
-        measurement = (
-            session.query(Measurement).filter(Measurement.id == self.meas_id).one_or_none()
-        )
+        measurement = session.query(Measurement).filter(Measurement.id == self.meas_id).one_or_none()
 
         if measurement.user:
             self.measurer.setText(measurement.user.name)
@@ -255,9 +248,7 @@ class MeasurementWidget(QtWidgets.QWidget):
         db = database
         session = db.Session()
 
-        measurement = (
-            session.query(Measurement).filter(Measurement.id == self.meas_id).one_or_none()
-        )
+        measurement = session.query(Measurement).filter(Measurement.id == self.meas_id).one_or_none()
 
         # Disconnect all signals
         try:
@@ -327,9 +318,7 @@ class MeasurementWidget(QtWidgets.QWidget):
         db = database
 
         session = db.Session()
-        session.query(Result).filter_by(measurementID=self.meas_id, column=col, row=row).update(
-            {Result.valid: valid},
-        )
+        session.query(Result).filter_by(measurementID=self.meas_id, column=col, row=row).update({Result.valid: valid})
         session.commit()
 
         # Tell views about change

--- a/src/mcr_analyzer/ui/models.py
+++ b/src/mcr_analyzer/ui/models.py
@@ -12,11 +12,7 @@ from mcr_analyzer.database.models import Measurement, Result
 
 
 class MeasurementTreeItem:
-    def __init__(
-        self,
-        tree_item_data: list,
-        parent_tree_item: typing.Self | None = None,
-    ):
+    def __init__(self, tree_item_data: list, parent_tree_item: typing.Self | None = None):
         self._tree_item_data = tree_item_data
         self._parent_tree_item = parent_tree_item
         self._child_tree_items: list[MeasurementTreeItem] = []
@@ -81,12 +77,7 @@ class MeasurementTreeModel(QtCore.QAbstractItemModel):
 
         self._setup_model_data()
 
-    def index(
-        self,
-        row: int,
-        column: int,
-        parent: QtCore.QModelIndex = QtCore.QModelIndex(),
-    ):
+    def index(self, row: int, column: int, parent: QtCore.QModelIndex = QtCore.QModelIndex()):
         if not self.hasIndex(row, column, parent):
             return QtCore.QModelIndex()
 
@@ -109,10 +100,7 @@ class MeasurementTreeModel(QtCore.QAbstractItemModel):
     def parent(self) -> QtCore.QObject:
         ...
 
-    def parent(
-        self,
-        child: QtCore.QModelIndex = QtCore.QModelIndex(),
-    ):
+    def parent(self, child: QtCore.QModelIndex = QtCore.QModelIndex()):
         if not child.isValid():
             return QtCore.QModelIndex()
 
@@ -141,11 +129,7 @@ class MeasurementTreeModel(QtCore.QAbstractItemModel):
 
         return parent_tree_item.column_count()
 
-    def data(
-        self,
-        index: QtCore.QModelIndex,
-        role: int = QtCore.Qt.ItemDataRole.DisplayRole,
-    ):
+    def data(self, index: QtCore.QModelIndex, role: int = QtCore.Qt.ItemDataRole.DisplayRole):
         if not index.isValid():
             return None
 
@@ -195,10 +179,7 @@ class MeasurementTreeModel(QtCore.QAbstractItemModel):
         for day in self.session.query(Measurement).group_by(
             sqlalchemy.func.strftime("%Y-%m-%d", Measurement.timestamp),
         ):
-            date_row_tree_item = MeasurementTreeItem(
-                [str(day.timestamp.date()), None, None],
-                self._root_tree_item,
-            )
+            date_row_tree_item = MeasurementTreeItem([str(day.timestamp.date()), None, None], self._root_tree_item)
 
             self._root_tree_item.append_child_tree_item(date_row_tree_item)
 
@@ -231,9 +212,7 @@ class ResultTableModel(QtCore.QAbstractTableModel):
         self.db = database
         self.session = self.db.Session()
 
-        self.measurement = (
-            self.session.query(Measurement).filter(Measurement.id == id).one_or_none()
-        )
+        self.measurement = self.session.query(Measurement).filter(Measurement.id == id).one_or_none()
         self.chip = self.measurement.chip
         self.results = None
         self.means = None
@@ -256,11 +235,7 @@ class ResultTableModel(QtCore.QAbstractTableModel):
 
         return self.chip.columnCount
 
-    def data(
-        self,
-        index: QtCore.QModelIndex,
-        role: int = QtCore.Qt.ItemDataRole.DisplayRole,
-    ):
+    def data(self, index: QtCore.QModelIndex, role: int = QtCore.Qt.ItemDataRole.DisplayRole):
         if not index.isValid():
             return None
 
@@ -298,17 +273,11 @@ class ResultTableModel(QtCore.QAbstractTableModel):
                 return_value = _get_qtgui_qfont_bold()
 
             case QtCore.Qt.ItemDataRole.ForegroundRole if result:
-                color = (
-                    QtCore.Qt.GlobalColor.darkGreen
-                    if result.valid
-                    else QtCore.Qt.GlobalColor.darkRed
-                )
+                color = QtCore.Qt.GlobalColor.darkGreen if result.valid else QtCore.Qt.GlobalColor.darkRed
                 return_value = QtGui.QBrush(color)
 
             case QtCore.Qt.ItemDataRole.TextAlignmentRole:
-                return_value = (
-                    QtCore.Qt.AlignmentFlag.AlignRight | QtCore.Qt.AlignmentFlag.AlignVCenter
-                )
+                return_value = QtCore.Qt.AlignmentFlag.AlignRight | QtCore.Qt.AlignmentFlag.AlignVCenter
 
         return return_value
 
@@ -354,9 +323,7 @@ class ResultTableModel(QtCore.QAbstractTableModel):
     def update(self):
         # Limit DB queries to 500ms
         database_query_limit_in_milliseconds = 500
-        if (
-            time.monotonic() * 1000 - self.last_update <= database_query_limit_in_milliseconds
-        ) and self.cache_valid:
+        if (time.monotonic() * 1000 - self.last_update <= database_query_limit_in_milliseconds) and self.cache_valid:
             return
 
         if not self.cache_valid:

--- a/src/mcr_analyzer/ui/welcome.py
+++ b/src/mcr_analyzer/ui/welcome.py
@@ -19,9 +19,7 @@ class WelcomeWidget(QtWidgets.QWidget):
         self.text = QtWidgets.QLabel(welcome_msg)
         layout.addWidget(self.text)
         self.new_button = QtWidgets.QPushButton(
-            self.style().standardIcon(
-                QtWidgets.QStyle.StandardPixmap.SP_FileIcon,  # cSpell:ignore Pixmap
-            ),
+            self.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_FileIcon),  # cSpell:ignore Pixmap
             "Create &new database...",
         )
         self.new_button.setIconSize(QtCore.QSize(48, 48))
@@ -97,7 +95,5 @@ def _update_settings_recent_files(file_name):
 
     settings.setValue(
         "Session/Files",
-        util.simplify_list(
-            recent_files[0 : settings.value("Preferences/MaxRecentFiles", 5)],
-        ),
+        util.simplify_list(recent_files[0 : settings.value("Preferences/MaxRecentFiles", 5)]),
     )

--- a/tests/io/test___image.py
+++ b/tests/io/test___image.py
@@ -11,20 +11,11 @@ from mcr_analyzer.io.image import Image
 @pytest.fixture(
     scope="session",
     params=[
-        (
-            "txt",
-            b"5\n3\n\n0\n1\n2\n3\n4\n253\n254\n255\n256\n257\n65531\n65532\n65533\n65534\n65535\n",
-        ),
-        (
-            "pgm",
-            b"P2\n5 3\n65535\n\n0 1 2 3 4\n253 254 255 256 257\n65531 65532 65533 65534 65535\n",
-        ),
+        ("txt", b"5\n3\n\n0\n1\n2\n3\n4\n253\n254\n255\n256\n257\n65531\n65532\n65533\n65534\n65535\n"),
+        ("pgm", b"P2\n5 3\n65535\n\n0 1 2 3 4\n253 254 255 256 257\n65531 65532 65533 65534 65535\n"),
     ],
 )
-def tmp_img(
-    request: pytest.FixtureRequest,
-    tmp_path_factory: pytest.TempPathFactory,
-) -> Generator[Image, None, None]:
+def tmp_img(request: pytest.FixtureRequest, tmp_path_factory: pytest.TempPathFactory) -> Generator[Image, None, None]:
     file = tmp_path_factory.mktemp("data").joinpath(f"img.{request.param[0]}")
 
     with Path(file).open("wb") as f:

--- a/tests/ui/test___main_window.py
+++ b/tests/ui/test___main_window.py
@@ -18,10 +18,7 @@ def main_window(qtbot: QtBot) -> Generator[MainWindow, None, None]:
     main_window.close()
 
 
-def test___main_window__launch(
-    main_window: MainWindow,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test___main_window__launch(main_window: MainWindow, monkeypatch: pytest.MonkeyPatch) -> None:
     exit_calls = []
     exit_code = 1
 


### PR DESCRIPTION
- Match the old configuration
- Suitable for today's high-resolution screens and relatively long and informative variable and function names
- Recommended choice by Hatch